### PR TITLE
Remove thread-pool-cpp.cpp from source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ if(WITH_CPP_THREADS)
     set(SOURCE_FILES ${SOURCE_FILES}
 	${BENCHMARK_CANDIDATES_DIR}/cpp_threads/cpp_threads.cpp
 	${BENCHMARK_CANDIDATES_DIR}/sean_parent/sean_parent.cpp
-	${BENCHMARK_CANDIDATES_DIR}/progschj_ThreadPool/progschj_ThreadPool.cpp
-	${BENCHMARK_CANDIDATES_DIR}/thread-pool-cpp/thread-pool-cpp.cpp)
+	${BENCHMARK_CANDIDATES_DIR}/progschj_ThreadPool/progschj_ThreadPool.cpp)
 endif()
 if(WITH_GCD)
     set(SOURCE_FILES ${SOURCE_FILES}


### PR DESCRIPTION
thread-pool-cpp.cpp does not exist in [inkooboo/thread-pool-cpp](https://github.com/inkooboo/thread-pool-cpp).